### PR TITLE
Feature / Limit the numbers of scores in the feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).limit(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -18,6 +18,7 @@ describe Api::ScoresController, type: :request do
       expect(response).to have_http_status(:ok)
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
+      
       expect(scores.size).to eq 3
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -18,13 +18,26 @@ describe Api::ScoresController, type: :request do
       expect(response).to have_http_status(:ok)
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
-
       expect(scores.size).to eq 3
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99
       expect(scores[0]['played_at']).to eq '2021-06-20'
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
+    end
+
+    it 'should limit the number of scores in the feed' do
+      30.times do
+        create(:score, user: @user1, total_score: 79, played_at: '2023-09-24')
+      end
+
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
     end
   end
 

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -18,7 +18,7 @@ describe Api::ScoresController, type: :request do
       expect(response).to have_http_status(:ok)
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
-      
+
       expect(scores.size).to eq 3
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -18,7 +18,6 @@ describe Api::ScoresController, type: :request do
       expect(response).to have_http_status(:ok)
       response_hash = JSON.parse(response.body)
       scores = response_hash['scores']
-      
       expect(scores.size).to eq 3
       expect(scores[0]['user_name']).to eq 'User2'
       expect(scores[0]['total_score']).to eq 99


### PR DESCRIPTION
Fixes: https://github.com/AACraiu/golfr_backend/issues/21

**Changes**
I added a limit of 25 in user_feed to show only 25 scores on page and I added a test to verify this.

**Before**
<img width="975" alt="Captură de ecran din 2023-10-09 la 18 06 17" src="https://github.com/roxanaoana24/golfr_backend/assets/139353920/e6f084cf-9bee-411e-bd63-ca2655e653ac">


**After**
<img width="975" alt="Captură de ecran din 2023-10-09 la 18 05 58" src="https://github.com/roxanaoana24/golfr_backend/assets/139353920/bc2afa46-23f2-4e27-9e03-b2a1de3ff9f1">


